### PR TITLE
Schemas Validation for Type Guarding

### DIFF
--- a/dist/logger.js
+++ b/dist/logger.js
@@ -1,0 +1,131 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const winston = __importStar(require("winston"));
+require("dotenv/config");
+var LogLevel;
+(function (LogLevel) {
+    LogLevel[LogLevel["Silent"] = 0] = "Silent";
+    LogLevel[LogLevel["Info"] = 1] = "Info";
+    LogLevel[LogLevel["Debug"] = 2] = "Debug";
+})(LogLevel || (LogLevel = {}));
+/**
+ * Logger class for handling application logs.
+ */
+class Logger {
+    /**
+     * Create a new Logger instance.
+     * @constructor
+     */
+    constructor() {
+        this.logLevel = this.getLogLevelFromEnv();
+        this.logFileName = process.env.LOG_FILE;
+        // Check if LOG_FILE is defined; exit with code 1 if not
+        if (!this.logFileName) {
+            process.exit(1);
+        }
+        const customFormat = winston.format.printf(({ timestamp, message }) => {
+            return `${timestamp} ${message}`;
+        });
+        const fileTransportOptions = {
+            filename: this.logFileName,
+        };
+        this.loggerMain = winston.createLogger({
+            level: this.logLevel >= LogLevel.Info ? 'info' : 'silent',
+            format: winston.format.combine(winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss.SSSZZ' }), // Use the custom format with timezone information
+            customFormat),
+            transports: [
+                new winston.transports.File(Object.assign(Object.assign({}, fileTransportOptions), { format: customFormat })),
+            ],
+        });
+        this.loggerDebug = winston.createLogger({
+            level: 'debug',
+            format: winston.format.combine(winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss.SSSZZ' }), // Use the custom format with timezone information
+            customFormat),
+            transports: [
+                new winston.transports.File(Object.assign(Object.assign({}, fileTransportOptions), { format: customFormat })),
+            ],
+        });
+        this.loggerError = winston.createLogger({
+            level: 'error',
+            format: winston.format.combine(winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss.SSSZZ' }), // Use the custom format with timezone information
+            customFormat),
+            transports: [
+                new winston.transports.File(Object.assign(Object.assign({}, fileTransportOptions), { format: customFormat })),
+            ],
+        });
+    }
+    /**
+     * Get the log level from the environment variable LOG_LEVEL.
+     * @private
+     */
+    getLogLevelFromEnv() {
+        const logLevel = process.env.LOG_LEVEL;
+        switch (logLevel) {
+            case '0':
+                return LogLevel.Silent;
+            case '2':
+                return LogLevel.Debug;
+            case '1':
+            default:
+                return LogLevel.Info;
+        }
+    }
+    /**
+     * Log a debug message.
+     * @param {string} message - The debug message to log.
+     */
+    debug(message) {
+        console.log(message);
+        if (this.logLevel >= LogLevel.Debug) {
+            this.loggerDebug.debug(message);
+        }
+    }
+    /**
+     * Log an information message.
+     * @param {string} message - The information message to log.
+     */
+    info(message) {
+        console.log(message);
+        if (this.logLevel >= LogLevel.Info) {
+            this.loggerMain.info(message);
+        }
+    }
+    /**
+     * Log a warning message.
+     * @param {string} message - The warning message to log.
+     */
+    warn(message) {
+        console.log(message);
+        if (this.logLevel >= LogLevel.Info) {
+            this.loggerMain.warn(message);
+        }
+    }
+    /**
+     * Log an error message.
+     * @param {string} message - The error message to log.
+     */
+    error(message) {
+        this.loggerError.error(message);
+    }
+}
+// Export a singleton instance of the Logger
+exports.default = new Logger();

--- a/dist/schemas.js
+++ b/dist/schemas.js
@@ -1,0 +1,13 @@
+"use strict";
+// for consistency: 
+// import * as Schemas from './schemas';
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Actions = void 0;
+// used in package history, currently out of scope
+var Actions;
+(function (Actions) {
+    Actions["CREATE"] = "CREATE";
+    Actions["UPDATE"] = "UPDATE";
+    Actions["DOWNLOAD"] = "DOWNLOAD";
+    Actions["RATE"] = "RATE";
+})(Actions = exports.Actions || (exports.Actions = {}));

--- a/dist/server/server.js
+++ b/dist/server/server.js
@@ -1,0 +1,505 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const jwt = require('jsonwebtoken');
+const express_1 = __importDefault(require("express"));
+const body_parser_1 = __importDefault(require("body-parser"));
+const server_errors_1 = require("./server_errors");
+const dbCommunicator_1 = __importDefault(require("../dbCommunicator"));
+const logger_1 = __importDefault(require("../logger"));
+// Example Request: curl -X POST -H "Content-Type: application/json" -d 
+//'{"name": "Sample Package", "version": "1.0.0", "data": {"URL": "https://example.com/package.zip"}}' http://localhost:3000/packages
+/**
+* PackageManagementAPI
+*
+*
+* Current Progress:
+* 1. Most of Package Ingestion is Complete (handleCreatePackage), URL and zip content can
+* both be analyzed to get metric scores, however, adding package to data base and creating a
+* response code still needs to be done.
+*
+* 2. Created skeleton responses for all endpoints ( a lot should just be data base queries now and formatting return)
+*
+* Need to be done:
+* 1. DataBase queries for all functions - database end, functions in development
+* 2. Authentication - database end, functions in development
+* 3. Return objects (for successfull queries) - TODO
+*
+* Issues I see:
+* 1. Their code is slow
+* 2. we need to update their Ramp_Up_Score, I think it is always < 0.5
+* 3. We need to include the new metrics
+*
+* Testing:
+* 1. Currently don't have Unit Tests set up
+* 2. Can use make_test_requests.py and PackageContent to test
+*
+* TODO, and SWITCH are used to find places that need to be updated
+*/
+class PackageManagementAPI {
+    constructor() {
+        this.database = dbCommunicator_1.default;
+        this.app = (0, express_1.default)();
+        this.app.use(body_parser_1.default.json());
+        // Middleware
+        // this.app.use(this.authenticate);
+        this.app.use(this.ErrorHandler);
+        // Define routes
+        this.app.get('/', this.handleDefault.bind(this));
+        this.app.post('/packages', this.handleSearchPackages.bind(this));
+        this.app.delete('/reset', this.handleReset.bind(this));
+        this.app.get('/package/:id', this.handleGetPackageById.bind(this));
+        this.app.put('/package/:id', this.handleUpdatePackageById.bind(this));
+        this.app.delete('/package/:id', this.handleDeletePackageById.bind(this));
+        this.app.post('/package', this.handleCreatePackage.bind(this));
+        this.app.get('/package/:id/rate', this.handleRatePackage.bind(this));
+        this.app.put('/authenticate', this.handleAuthenticateUser.bind(this));
+        this.app.get('/package/byName/:name', this.handleGetPackageByName.bind(this));
+        this.app.delete('/package/byName/:name', this.handleDeletePackageByName.bind(this));
+        this.app.post('/package/byRegEx', this.handleSearchPackagesByRegex.bind(this));
+    }
+    // Returns the Express app object (used in testing)
+    getApp() {
+        return this.app;
+    }
+    // Middleware for error handling
+    ErrorHandler(err, req, res, next) {
+        let errorMessage;
+        let statusCode;
+        // Collect multiple errors in an array
+        const errors = Array.isArray(err) ? err : [err];
+        if (errors.length > 1) {
+            err = new server_errors_1.AggregateError(errors);
+        }
+        errorMessage = err.message;
+        statusCode = (err instanceof server_errors_1.Server_Error) ? err.num :
+            (err instanceof server_errors_1.AggregateError) ? 500 : // TODO replace with more appropriate error code, or add .num to AggregateError
+                500; // default to 500
+        // Log and send the error          
+        logger_1.default.error(`${err}`); // TODO replace with actual error logging logic
+        res.status(statusCode).json({ error: errorMessage });
+    }
+    // Middleware for authentication (placeholder)
+    // curently not working???? idk y
+    authenticate(req, res, next) {
+        // Check the request path to skip authentication for specific routes
+        if (req.path === '/authenticate') {
+            next(); // Skip authentication for the /authenticate route
+        }
+        // Skeleton authentication logic (replace with actual logic)
+        // For example, you can check for a valid token here
+        // let userAPIKey = helper.getUserAPIKey(req.body.User.name, req.body.Secret.password);
+        //Should we pass a userPermission to the function called?
+        if (true) {
+            next(); // Authentication successful
+        }
+        throw new server_errors_1.Server_Error(401, 'Authentication failed');
+    }
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    ////////////////////////////////////////////////////////// ENDPOINTS /////////////////////////////////////////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // endpoint: '/' GET
+    handleDefault(req, res) {
+        res.send('Welcome to the package management API!');
+    }
+    // endpoint: '/packages' POST
+    // TODO test
+    handleSearchPackages(req, res) {
+        return __awaiter(this, void 0, void 0, function* () {
+            /**
+              * 200
+              List of packages
+              
+              * 400
+              There is missing field(s) in the PackageQuery/AuthenticationToken or it is formed improperly, or the AuthenticationToken is invalid.
+              
+              * 413
+              Too many packages returned.
+              */
+            try {
+                const data = req.body;
+                let dbResp = [];
+                if (!Array.isArray(data)) {
+                    throw new server_errors_1.Server_Error(400, "There is missing field(s) in the PackageQuery/AuthenticationToken or it is formed improperly, or the AuthenticationToken is invalid.");
+                }
+                if (data.length > 100) {
+                    throw new server_errors_1.Server_Error(413, "Too many packages returned."); // don't actually know what to do for this error
+                }
+                // ask database and process
+                data.forEach((query) => __awaiter(this, void 0, void 0, function* () {
+                    // Query the database for the requested packages
+                    const result = yield helper.queryForPackage(query);
+                    dbResp.push(result);
+                }));
+                res.status(200).json(dbResp);
+            }
+            catch (e) {
+                if (e instanceof server_errors_1.Server_Error) {
+                    throw e;
+                }
+                else { // req.body does not conform to Schemas.PackageQuery
+                    throw new server_errors_1.Server_Error(400, "There is missing field(s) in the PackageQuery/AuthenticationToken or it is formed improperly, or the AuthenticationToken is invalid.");
+                }
+            }
+        });
+    }
+    // zendpoint: '/package' POST
+    // TODO validate helpers and test
+    handleCreatePackage(req, res) {
+        return __awaiter(this, void 0, void 0, function* () {
+            /**
+              * 201
+              Success. Check the ID in the returned metadata for the official ID
+              
+              * 400
+              There is missing field(s) in the PackageData/AuthenticationToken or it is formed improperly (e.g. Content and URL are both set), or the AuthenticationToken is invalid.
+              
+              * 409
+              Package exists already.
+              
+              * 424
+              Package is not uploaded due to the disqualified rating.
+              */
+            try {
+                const newPackage = req.body; // url or base64
+                let result;
+                if (!newPackage) {
+                    throw new server_errors_1.Server_Error(400, 'There is missing field(s) in the PackageData/AuthenticationToken or it is formed improperly (e.g. Content and URL are both set), or the AuthenticationToken is invalid.');
+                }
+                else if ( /* is a url, TODO insert logic to check */true) {
+                    result = yield helper.APIHelpPackageURL(newPackage, 'no js program?');
+                }
+                else { // how to handle base64????
+                    result = /* await  */ helper.APIHelpPackageContent(newPackage, 'no js program');
+                }
+            }
+            catch (e) {
+                if (e instanceof server_errors_1.Server_Error) {
+                    throw e;
+                }
+                else { // might never reach this branch, is likely caught in helper functions, but just in case
+                    throw new server_errors_1.Server_Error(400, 'There is missing field(s) in the PackageData/AuthenticationToken or it is formed improperly (e.g. Content and URL are both set), or the AuthenticationToken is invalid.');
+                }
+            }
+            res.status(201).json(result);
+        });
+    }
+    // endpoint: '/reset' DELETE
+    // TODO test
+    handleReset(req, res) {
+        /**
+          * 200
+          Registry is reset.
+          
+          * 400
+          There is missing field(s) in the AuthenticationToken or it is formed improperly, or the AuthenticationToken is invalid.
+          
+          * 401
+          You do not have permission to reset the registry.
+          */
+        // Check if the user is an admin
+        try {
+            const data = req.body.User;
+            if (!data.isAdmin) {
+                throw new server_errors_1.Server_Error(401, 'You do not have permission to reset the registry.');
+            }
+            // Pass user to Database to authenticate token and reset if valid
+            const result = this.database.resetRegistry(data);
+            if (!result) {
+                throw new server_errors_1.Server_Error(400, 'There is missing field(s) in the AuthenticationToken or it is formed improperly, or the AuthenticationToken is invalid.');
+            }
+        }
+        catch (e) {
+            if (e instanceof server_errors_1.Server_Error) {
+                throw e;
+            }
+            else { // req.body does not conform to Schemas.User
+                throw new server_errors_1.Server_Error(400, 'There is missing field(s) in the AuthenticationToken or it is formed improperly, or the AuthenticationToken is invalid.');
+            }
+        }
+        res.json({ message: 'System reset successfully' });
+    }
+    // endpoint: '/package/:id' GET
+    // TODO test
+    handleGetPackageById(req, res) {
+        /**
+          * 200
+          Return the package. Content is required.
+          
+          * 400
+          There is missing field(s) in the PackageID/AuthenticationToken or it is formed improperly, or the AuthenticationToken is invalid.
+          
+          * 404
+          Package does not exist.
+          */
+        const packageId = req.params.id;
+        // Check if packageId is provided and is not empty
+        if (!packageId) {
+            throw new server_errors_1.Server_Error(400, 'Package ID is missing or invalid.');
+        }
+        // Perform database query or other actions to get the package by ID
+        // For demonstration purposes, let's assume you have a packages database and a function getPackageById
+        const package_result = this.database.getPackageById(packageId);
+        if (!package_result) {
+            // Package not found
+            throw new server_errors_1.Server_Error(404, 'Package not found.');
+        }
+        // Successfully retrieved the package
+        return res.status(200).json(package_result);
+    }
+    // endpoint: '/package/:id' PUT
+    // TODO test
+    handleUpdatePackageById(req, res) {
+        /**
+          * 200
+          Version is updated.
+          
+          * 400
+          There is missing field(s) in the PackageID/AuthenticationToken or it is formed improperly, or the AuthenticationToken is invalid.
+          
+          * 404
+          Package does not exist.
+          */
+        try {
+            const packageId = req.params.id;
+            const updatedPackageData = req.body;
+            // Update the package (replace this with your actual update logic)
+            // For demonstration purposes, let's assume you have a packages database and a function updatePackageById
+            const updatedPackage = this.database.updatePackageById(packageId, updatedPackageData);
+            if (!updatedPackage) {
+                // Package does not exist
+                throw new server_errors_1.Server_Error(404, 'Package not found.');
+            }
+        }
+        catch (e) {
+            if (e instanceof server_errors_1.Server_Error) {
+                throw e;
+            }
+            else { // req.body does not conform to Schemas.Package
+                throw new server_errors_1.Server_Error(400, 'There is missing field(s) in the PackageID/AuthenticationToken or it is formed improperly, or the AuthenticationToken is invalid.');
+            }
+        }
+        // Successfully updated package
+        return res.status(200).json('Version is updated.');
+    }
+    // endpoint: '/package/:id' DELETE
+    // TODO test
+    handleDeletePackageById(req, res) {
+        /**
+          * 200
+          Version is deleted.
+          
+          * 400
+          There is missing field(s) in the PackageID/AuthenticationToken or it is formed improperly, or the AuthenticationToken is invalid.
+          
+          * 404
+          Package does not exist.
+          */
+        const packageId = req.params.id;
+        // Check if the package ID is provided
+        if (!packageId) {
+            throw new server_errors_1.Server_Error(400, 'Package ID is missing or invalid.');
+        }
+        // Perform database delete or other actions to delete the package
+        // For demonstration purposes, let's assume you have a packages database and a function deletePackageById
+        const deletedPackage = this.database.deletePackageById(packageId);
+        if (!deletedPackage) {
+            // Package does not exist
+            throw new server_errors_1.Server_Error(404, 'Package not found.');
+        }
+        // Successfully deleted package
+        return res.status(200).json({
+            message: 'Package is deleted successfully.'
+        });
+    }
+    // endpoint: '/package/:id/rate' GET
+    // TODO test
+    handleRatePackage(req, res) {
+        /**
+          * 200
+          Return the rating. Only use this if each metric was computed successfully.
+
+          * 400
+          There is missing field(s) in the PackageID/AuthenticationToken or it is formed improperly, or the AuthenticationToken is invalid.
+          
+          * 404
+          Package does not exist.
+          
+          * 500
+          The package rating system choked on at least one of the metrics.
+          */
+        const packageId = req.params.id;
+        // Check if the package ID is provided
+        if (!packageId) {
+            throw new server_errors_1.Server_Error(400, 'Package ID is missing or invalid.');
+        }
+        // Perform rating logic or database updates here
+        // For demonstration purposes, let's assume you have a package ratings database and a function ratePackage
+        const ratedPackage = this.database.getPackageRatings(packageId);
+        if (!ratedPackage) {
+            // Package does not exist
+            throw new server_errors_1.Server_Error(404, 'Package not found.');
+        }
+        // Successfully rated package
+        return res.status(200).json(ratedPackage);
+    }
+    // endpoint: '/authenticate' PUT
+    // TODO currently out of scope, will implement if we have time
+    handleAuthenticateUser(req, res) {
+        return __awaiter(this, void 0, void 0, function* () {
+            throw new server_errors_1.Server_Error(501, 'This system does not support authentication.');
+            /**
+            *
+            * 200
+            Return an AuthenticationToken.
+            
+            * 400
+            There is missing field(s) in the AuthenticationRequest or it is formed improperly.
+            
+            401
+            The user or password is invalid.
+            
+            501
+            This system does not support authentication.
+            */
+            const secretKey = 'ECE461';
+            try {
+                const username = req.body.User.name;
+                const isAdmin = req.body.User.isAdmin;
+                const password = req.body.Secret.password;
+                if (!username || !password || req.body.User.isAdmin == null) {
+                    res.status(400).json({ error: 'Missing Fields' });
+                    return;
+                }
+                // Implement your actual user authentication logic here
+                const isValidUser = yield helper.getUserAPIKey(username, password);
+                //Temporary 'Base Case' Authentication
+                if (!isValidUser) {
+                    throw new server_errors_1.Server_Error(401, 'User or Password is invalid');
+                }
+                // Create the user object to include in the JWT token
+                const userObj = req.body.User;
+                /**
+                *  {
+                username: username,
+                isAdmin: isAdmin,
+            };
+            */
+                // Sign the JWT token
+                // const token = jwt.sign(userObj, secretKey, { expiresIn: '10h' });
+                // Return the token in the "Bearer" format
+                // res.status(200).send(`"bearer ${token}"`);
+            }
+            catch (error) {
+                res.status(400).json({ error: 'Missing Fields' });
+            }
+        });
+    }
+    // endpoint: '/package/byName/:name' GET
+    // TODO currently out of scope, will implement if we have time
+    handleGetPackageByName(req, res) {
+        throw new server_errors_1.Server_Error(501, 'This system does not support package history.');
+        /**
+        *
+        * 200
+        Return the package history.
+        
+        * 400
+        There is missing field(s) in the PackageID/AuthenticationToken or it is formed improperly, or the AuthenticationToken is invalid.
+        
+        404
+        Package does not exist.
+        */
+        const packageName = req.params.name;
+        // Check if the package name is provided
+        if (!packageName) {
+            throw new server_errors_1.Server_Error(400, 'Package name is missing or invalid.');
+        }
+        // Perform a database query or other actions to retrieve the package history by name
+        // For demonstration purposes, let's assume you have a packages database and a function getPackageByName
+        const packageHistory = {}; //getPackageByName(packageName);
+        if (!packageHistory) {
+            // Package does not exist
+            throw new server_errors_1.Server_Error(404, 'Package not found.');
+        }
+        // Successfully retrieved package history
+        return res.status(200).json(packageHistory);
+    }
+    // endpoint: '/package/byName/:name' DELETE
+    // TODO test
+    handleDeletePackageByName(req, res) {
+        /**
+         * 200
+         Package is deleted.
+        
+        * 400
+        There is missing field(s) in the PackageID/AuthenticationToken or it is formed improperly, or the AuthenticationToken is invalid.
+        
+        * 404
+        Package does not exist.
+        */
+        const packageName = req.params.name;
+        // Check if the package name is provided
+        if (!packageName) {
+            throw new server_errors_1.Server_Error(400, 'Package name is missing or invalid.');
+        }
+        // Perform database delete or other actions to delete the package by name
+        // For demonstration purposes, let's assume you have a packages database and a function deletePackageByName
+        const deletedPackage = this.database.deletePackageByName(packageName);
+        if (!deletedPackage) {
+            // Package does not exist
+            throw new server_errors_1.Server_Error(404, 'Package not found.');
+        }
+        // Successfully deleted package
+        return res.status(200).json('Package is deleted successfully.');
+    }
+    // endpoint: '/package/byRegEx' POST
+    // TODO test
+    handleSearchPackagesByRegex(req, res) {
+        /**
+         * 200
+         Return a list of packages.
+        
+        * 400
+        There is missing field(s) in the PackageRegEx/AuthenticationToken or it is formed improperly, or the AuthenticationToken is invalid.
+        
+        * 404
+        No package found under this regex.
+        */
+        const regexPattern = req.body.RegEx; // The property should match the name in the request body
+        // Check if the regex pattern is provided
+        if (!regexPattern) {
+            throw new server_errors_1.Server_Error(400, 'Regular expression pattern is missing.');
+        }
+        // Perform a search using the regex pattern
+        // For demonstration purposes, let's assume you have a packages database and a function searchPackagesByRegex
+        const searchResults = this.database.searchPackagesByRegex(regexPattern);
+        if (searchResults.length === 0) {
+            // No packages found matching the regex
+            throw new server_errors_1.Server_Error(404, 'No package found under this regex.');
+        }
+        // Successfully retrieved search results
+        return res.status(200).json(searchResults);
+    }
+    // Start the server on the specified port
+    start(port) {
+        this.app.listen(port, () => {
+            logger_1.default.info(`Server is running on port ${port}`);
+        });
+    }
+}
+const port = 3000;
+const apiServer = new PackageManagementAPI();
+logger_1.default.info(`Starting server on port ${port}`);
+apiServer.start(port);

--- a/dist/server/serverOLD.js
+++ b/dist/server/serverOLD.js
@@ -1,0 +1,598 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const express_1 = __importDefault(require("express"));
+const body_parser_1 = __importDefault(require("body-parser"));
+const helper = __importStar(require("./server_helper"));
+const dbCommunicator_1 = __importDefault(require("../dbCommunicator"));
+const server_errors_1 = require("./server_errors");
+const logger_1 = __importDefault(require("../logger"));
+const jwt = require('jsonwebtoken');
+// Example Request: curl -X POST -H "Content-Type: application/json" -d 
+//'{"name": "Sample Package", "version": "1.0.0", "data": {"URL": "https://example.com/package.zip"}}' http://localhost:3000/packages
+/**
+* PackageManagementAPI
+*
+* Functions:
+*  this.app.post('/packages', this.handleSearchPackages.bind(this));
+this.app.delete('/reset', this.handleReset.bind(this));
+this.app.get('/package/:id', this.handleGetPackageById.bind(this));
+this.app.put('/package/:id', this.handleUpdatePackageById.bind(this));
+this.app.delete('/package/:id', this.handleDeletePackageById.bind(this));
+this.app.post('/package', this.handleCreatePackage.bind(this));
+this.app.get('/package/:id/rate', this.handleRatePackage.bind(this));
+this.app.put('/authenticate', this.handleAuthenticateUser.bind(this));
+this.app.get('/package/byName/:name', this.handleGetPackageByName.bind(this));
+this.app.delete('/package/byName/:name', this.handleDeletePackageByName.bind(this));
+this.app.post('/package/byRegEx', this.handleSearchPackagesByRegex.bind(this));
+*
+* Current Progress:
+* 1. Most of Package Ingestion is Complete (handleCreatePackage), URL and zip content can
+* both be analyzed to get metric scores, however, adding package to data base and creating a
+* response code still needs to be done.
+*
+* 2. Created skeleton responses for all endpoints ( a lot should just be data base queries now and formatting return)
+*
+* Need to be done:
+* 1. DataBase queries for all functions - database end, functions in development
+* 2. Authentication - database end, functions in development
+* 3. Return objects (for successfull queries) - TODO
+*
+* Issues I see:
+* 1. Their code is slow
+* 2. we need to update their Ramp_Up_Score, I think it is always < 0.5
+* 3. We need to include the new metrics
+*
+* Testing:
+* 1. Currently don't have Unit Tests set up
+* 2. Can use make_test_requests.py and PackageContent to test
+*
+* TODO, and SWITCH are used to find places that need to be updated
+*/
+class PackageManagementAPI {
+    constructor() {
+        this.database = dbCommunicator_1.default;
+        this.app = (0, express_1.default)();
+        this.app.use(body_parser_1.default.json());
+        this.packages = [];
+        this.nextPackageId = 1;
+        // Middleware
+        // this.app.use(this.authenticate);
+        this.app.use(this.ErrorHandler);
+        // Define routes
+        this.app.get('/', this.handleDefault.bind(this));
+        this.app.post('/packages', this.handleSearchPackages.bind(this));
+        this.app.delete('/reset', this.handleReset.bind(this));
+        this.app.get('/package/:id', this.handleGetPackageById.bind(this));
+        this.app.put('/package/:id', this.handleUpdatePackageById.bind(this));
+        this.app.delete('/package/:id', this.handleDeletePackageById.bind(this));
+        this.app.post('/package', this.handleCreatePackage.bind(this));
+        this.app.get('/package/:id/rate', this.handleRatePackage.bind(this));
+        this.app.put('/authenticate', this.handleAuthenticateUser.bind(this));
+        this.app.get('/package/byName/:name', this.handleGetPackageByName.bind(this));
+        this.app.delete('/package/byName/:name', this.handleDeletePackageByName.bind(this));
+        this.app.post('/package/byRegEx', this.handleSearchPackagesByRegex.bind(this));
+    }
+    // Returns the Express app object (used in testing)
+    getApp() {
+        return this.app;
+    }
+    // Middleware for error handling
+    ErrorHandler(err, req, res, next) {
+        let errorMessage;
+        let statusCode;
+        // Collect multiple errors in an array
+        const errors = Array.isArray(err) ? err : [err];
+        if (errors.length > 1) {
+            err = new server_errors_1.AggregateError(errors);
+        }
+        errorMessage = err.message;
+        statusCode = (err instanceof server_errors_1.Server_Error) ? err.num :
+            (err instanceof server_errors_1.AggregateError) ? 500 : // TODO replace with more appropriate error code, or add .num to AggregateError
+                500; // default to 500
+        // Log and send the error          
+        logger_1.default.error(`${err}`); // TODO replace with actual error logging logic
+        res.status(statusCode).json({ error: errorMessage });
+    }
+    // Middleware for authentication (placeholder)
+    authenticate(req, res, next) {
+        // Check the request path to skip authentication for specific routes
+        if (req.path === '/authenticate') {
+            next(); // Skip authentication for the /authenticate route
+        }
+        // Skeleton authentication logic (replace with actual logic)
+        // For example, you can check for a valid token here
+        // let userAPIKey = helper.getUserAPIKey(req.body.User.name, req.body.Secret.password);
+        //Should we pass a userPermission to the function called?
+        if (true) {
+            next(); // Authentication successful
+        }
+        throw new server_errors_1.Server_Error(401, 'Authentication failed');
+    }
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    ////////////////////////////////////////////////////////// ENDPOINTS /////////////////////////////////////////////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // endpoint: '/' GET
+    handleDefault(req, res) {
+        res.send('Welcome to the package management API!');
+    }
+    // endpoint: '/packages' POST
+    // TODO test
+    handleSearchPackages(req, res) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // Skeleton package creation logic (replace with actual logic)
+            // You can access request data using req.body
+            const data = req.body;
+            let dbResp = [];
+            /**
+            * 200
+            List of packages
+            
+            400
+            There is missing field(s) in the PackageQuery/AuthenticationToken or it is formed improperly, or the AuthenticationToken is invalid.
+            
+            413
+            Too many packages returned.
+            */
+            if (!Array.isArray(data)) {
+                throw new server_errors_1.Server_Error(400, "There is missing field(s) in the PackageQuery/AuthenticationToken or it is formed improperly, or the AuthenticationToken is invalid.");
+            }
+            if (data.length > 100) {
+                throw new server_errors_1.Server_Error(413, "Too many packages returned."); // don't actually know what to do for this error
+            }
+            // ask database and process
+            data.forEach((query) => __awaiter(this, void 0, void 0, function* () {
+                // Query the database for the requested packages
+                const result = yield helper.queryForPackage(query);
+                dbResp.push(result);
+            }));
+            res.status(200).json(dbResp);
+        });
+    }
+    // zendpoint: '/package' POST
+    // TODO validate and test
+    handleCreatePackage(req, res) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // Skeleton package creation logic (replace with actual logic)
+            // You can access request data using req.body
+            //Check for improper stuff 400 code
+            /**
+             * 201
+             Success. Check the ID in the returned metadata for the official ID
+             *
+             * 400
+             There is missing field(s) in the PackageData/AuthenticationToken or it is formed improperly (e.g. Content and URL are both set), or the AuthenticationToken is invalid.
+             
+             
+             409
+             Package exists already.
+             
+             
+             424
+             Package is not uploaded due to the disqualified rating.
+             */
+            try {
+                if ("URL" in req.body && "Content" in req.body || !("JSProgram" in req.body)) {
+                    throw new server_errors_1.Server_Error(400, 'There is missing field(s) in the PackageData/AuthenticationToken or it is formed improperly (e.g. Content and URL are both set)');
+                }
+                if ("URL" in req.body) {
+                    const newPackage = req.body;
+                    const url = newPackage.URL;
+                    const JsProgram = newPackage.JsProgram;
+                    const result = yield helper.APIHelpPackageURL(url, JsProgram);
+                    if ('metadata' in result) {
+                        res.status(201).json(result);
+                    }
+                    else if ('package already exists' in result) {
+                        throw new server_errors_1.Server_Error(409, "Package exists already");
+                    }
+                    else {
+                        throw new server_errors_1.Server_Error(424, "Package Disqualified Rating");
+                    }
+                }
+                // Content needs progress. Can currently Unzip but don't know how to analyze the metric scores.
+                else if ("Content" in req.body) {
+                    const base64 = req.body.Content;
+                    const JSprogram = req.body.JsProgram;
+                    const URL = helper.APIHelpPackageContent(base64, JSprogram);
+                    let result = { error: "Package Disqualified Rating" };
+                    if (URL) {
+                        result = yield helper.APIHelpPackageURL(URL, JSprogram);
+                        logger_1.default.info(`${result}`);
+                    }
+                    if ('metadata' in result) {
+                        res.status(201).json(result);
+                    }
+                    else if ('package exists' in result) {
+                        throw new server_errors_1.Server_Error(409, "Package exists already");
+                    }
+                    else {
+                        throw new server_errors_1.Server_Error(424, "Package Disqualified Rating");
+                    }
+                }
+                else {
+                    throw new server_errors_1.Server_Error(400, 'There is missing field(s)');
+                }
+            }
+            catch (error) {
+                throw new server_errors_1.Server_Error(400, 'There is missing field(s) in the PackageData/AuthenticationToken or it is formed improperly (e.g. Content and URL are both set)');
+            }
+        });
+    }
+    // endpoint: '/reset' DELETE
+    // TODO test
+    handleReset(req, res) {
+        // Skeleton system reset logic (replace with actual logic)
+        // For example, you can clear data or perform other reset actions
+        // Respond with a success message
+        /**
+        * 200
+        Registry is reset.
+        
+        400
+        There is missing field(s) in the AuthenticationToken or it is formed improperly, or the AuthenticationToken is invalid.
+        
+        401
+        You do not have permission to reset the registry.
+        */
+        // Check if the user is an admin
+        const data = req.body.User;
+        if (!data.isAdmin) {
+            throw new server_errors_1.Server_Error(401, 'You do not have permission to reset the registry.');
+        }
+        // Pass user to Database to authenticate token and reset if valid
+        const result = this.database.resetRegistry(data);
+        if (!result) {
+            throw new server_errors_1.Server_Error(400, 'There is missing field(s) in the AuthenticationToken or it is formed improperly, or the AuthenticationToken is invalid.');
+        }
+        res.json({ message: 'System reset successfully' });
+    }
+    // endpoint: '/package/:id' GET
+    // TODO validate and test
+    handleGetPackageById(req, res) {
+        // Skeleton logic to retrieve a package by ID (replace with actual logic)
+        // You can access the ID using req.params.id
+        /**
+        *
+        * 200
+        Return the package. Content is required.
+        
+        * 400
+        There is missing field(s) in the PackageID/AuthenticationToken or it is formed improperly, or the AuthenticationToken is invalid.
+        
+        404
+        Package does not exist.
+        */
+        const packageId = req.params.id;
+        // Check if packageId is provided and is not empty
+        if (!packageId) {
+            throw new server_errors_1.Server_Error(400, 'Package ID is missing or invalid.');
+        }
+        // Perform database query or other actions to get the package by ID
+        // For demonstration purposes, let's assume you have a packages database and a function getPackageById
+        const package_result = this.database.getPackageById(packageId);
+        if (!package_result) {
+            // Package not found
+            throw new server_errors_1.Server_Error(404, 'Package not found.');
+        }
+        // Successfully retrieved the package
+        return res.status(200).json(package_result);
+    }
+    // endpoint: '/package/:id' PUT
+    // TODO update to utilize schemas, will be more simple
+    handleUpdatePackageById(req, res) {
+        // Skeleton logic to update a package by ID (replace with actual logic)
+        // You can access the ID using req.params.id and data using req.body
+        /**
+        * 200
+        Version is updated.
+        
+        400
+        There is missing field(s) in the PackageID/AuthenticationToken or it is formed improperly, or the AuthenticationToken is invalid.
+        
+        404
+        Package does not exist.
+        */
+        const packageId = req.params.id;
+        const updatedPackageData = req.body;
+        // Check for top-level required fields in the request body
+        const requiredTopLevelFields = ["metadata", "data"];
+        const missingTopLevelFields = requiredTopLevelFields.filter(field => !updatedPackageData[field]);
+        if (missingTopLevelFields.length > 0) {
+            throw new server_errors_1.Server_Error(400, `Missing required top-level fields: ${missingTopLevelFields.join(', ')}`);
+        }
+        // Check for required subfields within 'metadata' and 'data'
+        if (updatedPackageData.metadata) {
+            const requiredMetadataFields = ["Name", "Version", "ID"];
+            const missingMetadataFields = requiredMetadataFields.filter(field => !updatedPackageData.metadata[field]);
+            if (missingMetadataFields.length > 0) {
+                throw new server_errors_1.Server_Error(400, `Missing required 'metadata' subfields: ${missingMetadataFields.join(', ')}`);
+            }
+        }
+        if (updatedPackageData.data) {
+            const requiredDataFields = ["Content", "URL", "JSProgram"];
+            const missingDataFields = requiredDataFields.filter(field => !updatedPackageData.data[field]);
+            if (missingDataFields.length > 0) {
+                throw new server_errors_1.Server_Error(400, `Missing required 'data' subfields: ${missingDataFields.join(', ')}`);
+            }
+        }
+        // Update the package (replace this with your actual update logic)
+        // For demonstration purposes, let's assume you have a packages database and a function updatePackageById
+        const updatedPackage = this.database.updatePackageById(packageId, updatedPackageData);
+        if (!updatedPackage) {
+            // Package does not exist
+            throw new server_errors_1.Server_Error(404, 'Package not found.');
+        }
+        // Successfully updated package
+        return res.status(200).json({
+            message: 'Version is updated.',
+            updatedPackage
+        });
+    }
+    // endpoint: '/package/:id' DELETE
+    // TODO validate and test
+    handleDeletePackageById(req, res) {
+        // Skeleton logic to delete a package by ID (replace with actual logic)
+        // You can access the ID using req.params.id
+        /**
+        * 200
+        Version is deleted.
+        
+        400
+        There is missing field(s) in the PackageID/AuthenticationToken or it is formed improperly, or the AuthenticationToken is invalid.
+        
+        404
+        Package does not exist.
+        */
+        const packageId = req.params.id;
+        // Check if the package ID is provided
+        if (!packageId) {
+            throw new server_errors_1.Server_Error(400, 'Package ID is missing or invalid.');
+        }
+        // Perform database delete or other actions to delete the package
+        // For demonstration purposes, let's assume you have a packages database and a function deletePackageById
+        const deletedPackage = this.database.deletePackageById(packageId);
+        if (!deletedPackage) {
+            // Package does not exist
+            throw new server_errors_1.Server_Error(404, 'Package not found.');
+        }
+        // Successfully deleted package
+        return res.status(200).json({
+            message: 'Package is deleted successfully.'
+        });
+    }
+    // endpoint: '/package/:id/rate' GET
+    // TODO validate and test
+    handleRatePackage(req, res) {
+        // Skeleton logic to rate a package by ID (replace with actual logic)
+        // You can access the ID using req.params.id
+        /**
+        * 200
+        Return the rating. Only use this if each metric was computed successfully.
+        * 400
+        There is missing field(s) in the PackageID/AuthenticationToken or it is formed improperly, or the AuthenticationToken is invalid.
+        
+        404
+        Package does not exist.
+        
+        500
+        The package rating system choked on at least one of the metrics.
+        */
+        const packageId = req.params.id;
+        const ratingData = req.body;
+        // Check if the package ID is provided
+        if (!packageId) {
+            throw new server_errors_1.Server_Error(400, 'Package ID is missing or invalid.');
+        }
+        // Check for required fields in the rating data
+        const requiredFields = [
+            "BusFactor",
+            "Correctness",
+            "RampUp",
+            "ResponsiveMaintainer",
+            "LicenseScore",
+            "GoodPinningPractice",
+            "PullRequest",
+            "NetScore"
+        ];
+        const missingFields = requiredFields.filter(field => typeof ratingData[field] !== 'number');
+        if (missingFields.length > 0) {
+            throw new server_errors_1.Server_Error(400, `Missing or invalid rating fields: ${missingFields.join(', ')}`);
+        }
+        // Perform rating logic or database updates here
+        // For demonstration purposes, let's assume you have a package ratings database and a function ratePackage
+        const ratedPackage = {}; //ratePackage(packageId, ratingData);
+        if (!ratedPackage) {
+            // Package does not exist
+            throw new server_errors_1.Server_Error(404, 'Package not found.');
+        }
+        // Successfully rated package
+        return res.status(200).json(ratedPackage);
+    }
+    // endpoint: '/authenticate' PUT
+    // currently out of scope, will implement if we have time
+    handleAuthenticateUser(req, res) {
+        return __awaiter(this, void 0, void 0, function* () {
+            throw new server_errors_1.Server_Error(501, 'This system does not support authentication.');
+            /**
+            *
+            * 200
+            Return an AuthenticationToken.
+            
+            * 400
+            There is missing field(s) in the AuthenticationRequest or it is formed improperly.
+            
+            401
+            The user or password is invalid.
+            
+            501
+            This system does not support authentication.
+            */
+            const secretKey = 'ECE461';
+            try {
+                const username = req.body.User.name;
+                const isAdmin = req.body.User.isAdmin;
+                const password = req.body.Secret.password;
+                if (!username || !password || req.body.User.isAdmin == null) {
+                    res.status(400).json({ error: 'Missing Fields' });
+                    return;
+                }
+                // Implement your actual user authentication logic here
+                const isValidUser = yield helper.getUserAPIKey(username, password);
+                //Temporary 'Base Case' Authentication
+                if (!isValidUser) {
+                    throw new server_errors_1.Server_Error(401, 'User or Password is invalid');
+                }
+                // Create the user object to include in the JWT token
+                const userObj = req.body.User;
+                /**
+                *  {
+                username: username,
+                isAdmin: isAdmin,
+            };
+            */
+                // Sign the JWT token
+                // const token = jwt.sign(userObj, secretKey, { expiresIn: '10h' });
+                // Return the token in the "Bearer" format
+                // res.status(200).send(`"bearer ${token}"`);
+            }
+            catch (error) {
+                res.status(400).json({ error: 'Missing Fields' });
+            }
+        });
+    }
+    // endpoint: '/package/byName/:name' GET
+    // TODO validate and test
+    handleGetPackageByName(req, res) {
+        // Skeleton logic to retrieve a package by name (replace with actual logic)
+        // You can access the name using req.params.name
+        /**
+        *
+        * 200
+        Return the package history.
+        
+        * 400
+        There is missing field(s) in the PackageID/AuthenticationToken or it is formed improperly, or the AuthenticationToken is invalid.
+        
+        404
+        Package does not exist.
+        */
+        const packageName = req.params.name;
+        // Check if the package name is provided
+        if (!packageName) {
+            throw new server_errors_1.Server_Error(400, 'Package name is missing or invalid.');
+        }
+        // Perform a database query or other actions to retrieve the package history by name
+        // For demonstration purposes, let's assume you have a packages database and a function getPackageByName
+        const packageHistory = {}; //getPackageByName(packageName);
+        if (!packageHistory) {
+            // Package does not exist
+            throw new server_errors_1.Server_Error(404, 'Package not found.');
+        }
+        // Successfully retrieved package history
+        return res.status(200).json(packageHistory);
+    }
+    // endpoint: '/package/byName/:name' DELETE
+    // TODO validate and test
+    handleDeletePackageByName(req, res) {
+        // Skeleton logic to delete a package by name (replace with actual logic)
+        // You can access the name using req.params.name
+        /**
+        *
+        * 200
+        Package is deleted.
+        
+        * 400
+        There is missing field(s) in the PackageID/AuthenticationToken or it is formed improperly, or the AuthenticationToken is invalid.
+        
+        404
+        Package does not exist.
+        */
+        const packageName = req.params.name;
+        // Check if the package name is provided
+        if (!packageName) {
+            throw new server_errors_1.Server_Error(400, 'Package name is missing or invalid.');
+        }
+        // Perform database delete or other actions to delete the package by name
+        // For demonstration purposes, let's assume you have a packages database and a function deletePackageByName
+        const deletedPackage = false; //deletePackageByName(packageName);
+        if (!deletedPackage) {
+            // Package does not exist
+            throw new server_errors_1.Server_Error(404, 'Package not found.');
+        }
+        // Successfully deleted package
+        return res.status(200).json({
+            message: 'Package is deleted successfully.'
+        });
+    }
+    // endpoint: '/package/byRegEx' POST
+    // TODO validate and test
+    handleSearchPackagesByRegex(req, res) {
+        // Skeleton logic to search packages by regex (replace with actual logic)
+        // You can access the search parameters using req.body
+        /**
+        *
+        * 200
+        Return a list of packages.
+        
+        * 400
+        There is missing field(s) in the PackageRegEx/AuthenticationToken or it is formed improperly, or the AuthenticationToken is invalid.
+        
+        404
+        No package found under this regex.
+        */
+        const regexPattern = req.body.RegEx; // The property should match the name in the request body
+        // Check if the regex pattern is provided
+        if (!regexPattern) {
+            throw new server_errors_1.Server_Error(400, 'Regular expression pattern is missing.');
+        }
+        // Perform a search using the regex pattern
+        // For demonstration purposes, let's assume you have a packages database and a function searchPackagesByRegex
+        const searchResults = []; //searchPackagesByRegex(regexPattern);
+        if (searchResults.length === 0) {
+            // No packages found matching the regex
+            throw new server_errors_1.Server_Error(404, 'No package found under this regex.');
+        }
+        // Successfully retrieved search results
+        return res.status(200).json(searchResults);
+    }
+    // Start the server on the specified port
+    start(port) {
+        this.app.listen(port, () => {
+            logger_1.default.info(`Server is running on port ${port}`);
+        });
+    }
+}
+const apiServer = new PackageManagementAPI();
+logger_1.default.info(`Starting server on port 3000`);
+apiServer.start(3000); // alternative port for http - https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers

--- a/dist/server/server_errors.js
+++ b/dist/server/server_errors.js
@@ -1,0 +1,43 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.AggregateError = exports.Server_Error = void 0;
+/*
+ * ALL SERVER RELATED ERRORS BY CODE
+ * 400: Bad Request, missing field, improper format, invalid authentication token
+ * 401: Unauthorized permission, or username/password is invalid
+ * 404: Not Found, ie package does not exist
+ * 409: Conflict, ie package already exists
+ * 413: Payload Too Large, ie too many packages returned
+ * 424: Failed Dependency, ie package is not uploaded due to the disqualified rating.
+ * 500: Internal Server Error, ex database error
+ * 501: Not Implemented, ie API endpoint not implemented
+ */
+const DEFAULT_SERVER_ERRORS = {
+    400: "Bad Request",
+    401: "Unauthorized",
+    404: "Not Found",
+    409: "Conflict",
+    413: "Payload Too Large",
+    424: "Failed Dependency",
+    500: "Internal Server Error",
+    501: "Not Implemented"
+};
+class Server_Error extends Error {
+    constructor(num, str) {
+        let message = str != null ? str :
+            num in DEFAULT_SERVER_ERRORS ? DEFAULT_SERVER_ERRORS[num] :
+                "Unknown Server Error or Default Error not Found";
+        super(message);
+        this.name = num.toString();
+        this.num = num;
+    }
+}
+exports.Server_Error = Server_Error;
+class AggregateError extends Error {
+    constructor(errors) {
+        super('Multiple errors occurred');
+        this.name = 'AggregateError';
+        this.errors = errors;
+    }
+}
+exports.AggregateError = AggregateError;

--- a/dist/server/server_helper.js
+++ b/dist/server/server_helper.js
@@ -1,0 +1,184 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.queryForPackage = exports.getUserAPIKey = exports.APIHelpPackageURL = exports.APIHelpPackageContent = void 0;
+const { Buffer } = require('buffer');
+const AdmZip = require('adm-zip');
+const fs = __importStar(require("fs"));
+const console_1 = require("console");
+const adjusted_main_1 = require("../adjusted_main");
+const server_errors_1 = require("./server_errors");
+const dbCommunicator_1 = __importDefault(require("../dbCommunicator"));
+const logger_1 = __importDefault(require("../logger"));
+function APIHelpPackageContent(base64, JsProgram) {
+    const zipBuffer = Buffer.from(base64, 'base64');
+    const unzipDir = './src/cloned_repositories';
+    if (!fs.existsSync(unzipDir)) {
+        fs.mkdirSync(unzipDir);
+    }
+    let gitRemoteUrl = '';
+    let githubUrl = null;
+    try {
+        const zip = new AdmZip(zipBuffer);
+        const zipEntries = zip.getEntries();
+        let foundURL = false;
+        zipEntries.forEach((entry) => {
+            if (!entry.isDirectory && !foundURL) {
+                const entryName = entry.entryName;
+                const entryData = entry.getData();
+                const outputPath = `${unzipDir}/${entryName}`;
+                // Create subdirectories if they don't exist
+                const outputDir = outputPath.substring(0, outputPath.lastIndexOf('/'));
+                if (!fs.existsSync(outputDir)) {
+                    fs.mkdirSync(outputDir, { recursive: true });
+                }
+                // Write the entry data to the corresponding file
+                fs.writeFileSync(outputPath, entryData);
+                //logger.info(`Extracted: ${entryName}`);
+                // Check for package.json with GitHub URL
+                if (entryName.includes('package.json')) {
+                    //logger.info('here');
+                    const packageJson = JSON.parse(fs.readFileSync(outputPath, 'utf-8'));
+                    if (packageJson.repository && packageJson.repository.url) {
+                        gitRemoteUrl = packageJson.repository.url.split('+')[1].replace('.git', '');
+                        foundURL = true; // Set the flag to true when the URL is found
+                    }
+                }
+            }
+        });
+        fs.rmSync(unzipDir, { recursive: true });
+        //logger.info('ZIP file extraction complete.');
+        //logger.info(gitRemoteUrl)
+        return gitRemoteUrl;
+    }
+    catch (error) {
+        logger_1.default.error(`${error}`);
+        return gitRemoteUrl;
+    }
+}
+exports.APIHelpPackageContent = APIHelpPackageContent;
+function APIHelpPackageURL(url, JsProgram) {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+            const result = yield (0, adjusted_main_1.fetchDataAndCalculateScore)(url);
+            //Check to see if Scores Fulfill the threshold if not return a different return code
+            // Believe they all have to be over 0.5
+            const keys = Object.keys(result);
+            for (const key of keys) {
+                const value = result[key];
+                if (typeof value === 'number' && value < 0) {
+                    //logger.info(value)
+                    throw new server_errors_1.Server_Error(424, "Package is not uploaded due to the disqualified rating.");
+                }
+            }
+            const package_exists = false; //DataBase.ScanForPacakge(url)
+            if (package_exists) {
+                throw new server_errors_1.Server_Error(409, "Package already exists");
+            }
+            else {
+                //DataBase.AddPackage(url, metrics, ...)
+            }
+            // TODO Put in logic to store package in database and download as zipfile
+            //Check if already in database too should be something like:
+            // upload = DataBaseManager.InsertFromUrl(url, result)
+            // upload includes data for success_response or error
+            // if error in upload: {return alread_exists_response} else{} do whats below
+            const success_response = {
+                metadata: {
+                    Name: "Underscore",
+                    Version: "1.0.0",
+                    ID: "underscore"
+                },
+                data: "Base64 of zipfile"
+            };
+            return success_response;
+            //res.status(201).json(newPackage);
+        }
+        catch (error) {
+            // propogate error
+            throw new server_errors_1.Server_Error(400, "There is missing field(s) in the PackageQuery/AuthenticationToken or it is formed improperly, or the AuthenticationToken is invalid.");
+        }
+    });
+}
+exports.APIHelpPackageURL = APIHelpPackageURL;
+function getUserAPIKey(username, password) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const admin = username === "ece30861defaultadminuser" && password === "correcthorsebatterystaple123(!__+@**(A'\"`;DROP TABLE packages;";
+        if (admin) {
+            return true;
+        }
+        let authenication = yield dbCommunicator_1.default.authenticateUser(username, password);
+        if (!authenication) {
+            return false;
+        }
+        return authenication;
+    });
+}
+exports.getUserAPIKey = getUserAPIKey;
+// TODO explicitly define the typings and set return once dbCommunicator is implemented for package search
+/*
+    example input
+    {
+        "Version": "Exact (1.2.3)\nBounded range (1.2.3-2.1.0)\nCarat (^1.2.3)\nTilde (~1.2.0)",
+        "Name": "string"
+    }
+ */
+function queryForPackage(Input) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // process "Version"
+        const versionRegex = /\(([^)]+)\)/;
+        const lines = Input.Version.split('\n');
+        const versions = lines.map((line) => {
+            try {
+                const match = line.match(versionRegex);
+                if (!match) {
+                    throw console_1.error;
+                }
+                return match[1];
+            }
+            catch (error) {
+                throw new server_errors_1.Server_Error(400, "There is missing field(s) in the PackageQuery/AuthenticationToken or it is formed improperly, or the AuthenticationToken is invalid.");
+            }
+        });
+        // query DB for package based on name and each requested version
+        let foundPackages = [];
+        for (const version of versions) {
+            const packageData = yield dbCommunicator_1.default.getPackage(Input.Name, version);
+            if (packageData) {
+                foundPackages.push(packageData);
+            }
+        }
+        return foundPackages;
+    });
+}
+exports.queryForPackage = queryForPackage;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,6 +1,9 @@
 // for consistency: 
 // import * as Schemas from './schemas';
 
+import e from "express";
+import exp from "node:constants";
+
 
 // from inherited code
 export interface CLIOutput {
@@ -26,6 +29,9 @@ export type PackageName = string;
 // Unique identifier for a package.
 export type PackageID = string;
 
+// Version of a package.
+export type PackageVersion = string;
+
 // Package content as a binary zip
 export type PackageContent = string;
 
@@ -35,6 +41,21 @@ export type PackageURL = string;
 // Package content as a JS program
 export type PackageJSProgram = string;
 
+// Offset in pagination.
+export type EnumerateOffset = string;
+
+// A regular expression over package names and READMEs that is used for searching for a package
+export type PackageRegEx = string;
+
+// example: Exact (1.2.3) Bounded range (1.2.3-2.1.0) Carat (^1.2.3) Tilde (~1.2.0)
+export type SemverRange = string;
+
+// This is a "union" type.
+//     On package upload, either Content or URL should be set (should this be handled on frontend? --nate). If both are set, returns 400.
+//     On package update, exactly one field should be set.
+//     On download, the Content field should be set.
+export type PackageData = PackageContent | PackageURL | PackageJSProgram;
+
 // The "Name" and "Version" are used as a unique identifier pair when uploading a package.
 // The "ID" is used as an internal identifier for interacting with existing packages.
 export interface PackageMetadata {
@@ -42,12 +63,6 @@ export interface PackageMetadata {
     Version: string;
     ID: PackageID | null; // null opt since endpoint /package/byRegEx does not return id, allowing reuse of this interface
 }
-
-// This is a "union" type.
-//     On package upload, either Content or URL should be set (should this be handled on frontend? --nate). If both are set, returns 400.
-//     On package update, exactly one field should be set.
-//     On download, the Content field should be set.
-export type PackageData = PackageContent | PackageURL | PackageJSProgram;
 
 // Format of Packages
 export interface Package {
@@ -61,10 +76,12 @@ export interface User {
     isAdmin: boolean;
 }
 
+// inteface to allow for expansion of user authentication info
 export interface UserAuthenticationInfo {
     password: string;
 }
-    
+
+// necessary ratings schema
 export interface PackageRating {
     BusFactor: number;
     Correctness: number;
@@ -76,6 +93,8 @@ export interface PackageRating {
     NetScore: number;
 }
 
+
+// used in package history, currently out of scope
 export enum Actions {
     CREATE = "CREATE",
     UPDATE = "UPDATE",
@@ -83,6 +102,8 @@ export enum Actions {
     RATE = "RATE"
 }
 
+// currently out of scope, but would be used for package history additional requirement
+// if we have time to implement this it is here
 export interface PackageHistoryEntry {
     User: User;
     Date: string; // Date-time - Date of activity using ISO-8601 Datetime standard in UTC format.
@@ -94,17 +115,107 @@ export interface PackageHistoryEntry {
 // npm install --save @types/jsonwebtoken
 // if we find we have time to implement this, currently out of scope
 
-// example: Exact (1.2.3) Bounded range (1.2.3-2.1.0) Carat (^1.2.3) Tilde (~1.2.0)
-export type SemverRange = string;
-
 // Query for a package by name and version.
 export interface PackageQuery {
     Version: SemverRange;
     Name: PackageName;
 }
 
-// Offset in pagination.
-export type EnumerateOffset = string;
+// Evaluation of the various schemas
+// Type Guards
+export namespace Evaluate {
+    // ENUMS
+    export function isAction(obj: any): obj is Actions {
+        return obj && typeof obj === 'string' &&
+               (obj === Actions.CREATE || 
+                obj === Actions.UPDATE || 
+                obj === Actions.DOWNLOAD || 
+                obj === Actions.RATE);
+    }
 
-// A regular expression over package names and READMEs that is used for searching for a package
-export type PackageRegEx = string;
+    // TYPES
+    export function isPackageName(obj: any): obj is PackageName {
+        return obj && typeof obj === 'string';
+    }
+
+    export function isPackageID(obj: any): obj is PackageID {
+        return obj && typeof obj === 'string';
+    }
+
+    export function isPackageVersion(obj: any): obj is PackageVersion {
+        return obj && typeof obj === 'string';
+    }
+
+    // TODO - how to check if binary zip?
+    export function isPackageContent(obj: any): obj is PackageContent {
+        return obj && typeof obj === 'string';
+    }
+
+    // TODO - what urls are valid?
+    export function isPackageURL(obj: any): obj is PackageURL {
+        return obj && typeof obj === 'string';
+    }
+
+    // TODO - how to check if JS program?
+    export function isPackageJSProgram(obj: any): obj is PackageJSProgram {
+        return obj && typeof obj === 'string';
+    }
+    
+    export function isSemverRange(obj: any): obj is SemverRange {
+        return obj && typeof obj === 'string';
+    }
+
+    export function isPackageRegEx(obj: any): obj is PackageRegEx {
+        return obj && typeof obj === 'string';
+    }
+
+    // INTERFACES
+    export function isPackageMetadata(obj: any): obj is PackageMetadata {
+        return obj && isPackageName(obj.Name) && isPackageID(obj.ID) && isPackageVersion(obj.Version);
+    }
+
+    export function isPackageData(obj: any): obj is PackageData {
+        return obj && (isPackageContent(obj) || isPackageURL(obj) || isPackageJSProgram(obj));
+    }
+
+    export function isPackage(obj: any): obj is Package{
+        return obj && isPackageData(obj.data) && isPackageMetadata(obj.metadata);
+    }
+
+    export function isUser(obj: any): obj is User {
+        return obj && obj.name && obj.isAdmin && typeof obj.name === 'string' && typeof obj.isAdmin === 'boolean';
+    }
+    
+    export function isUserAuthenticationInfo(obj: any): obj is UserAuthenticationInfo {
+        return obj && obj.password && typeof obj.password === 'string';
+    }
+    
+    export function isPackageRating(obj: any): obj is PackageRating {
+        return (
+            obj && obj.BusFactor && obj.Correctness && obj.RampUp && obj.ResponsiveMaintainer && obj.LicenseScore && obj.GoodPinningPractice && obj.PullRequest && obj.NetScore &&
+            typeof obj.BusFactor === 'number' &&
+            typeof obj.Correctness === 'number' &&
+            typeof obj.RampUp === 'number' &&
+            typeof obj.ResponsiveMaintainer === 'number' &&
+            typeof obj.LicenseScore === 'number' &&
+            typeof obj.GoodPinningPractice === 'number' &&
+            typeof obj.PullRequest === 'number' &&
+            typeof obj.NetScore === 'number'
+        );
+    }
+    
+    export function isPackageHistoryEntry(obj: any): obj is PackageHistoryEntry {
+        return (
+            obj && obj.Date &&
+            typeof obj.Date === 'string' &&
+            isAction(obj.Action) &&
+            isUser(obj.User) &&
+            isPackageMetadata(obj.PackageMetadata)
+        );
+    }
+
+    export function isPackageQuery(obj: any): obj is PackageQuery {
+        return obj && isSemverRange(obj.Version) && isPackageName(obj.Name);
+    }
+    
+}

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -172,7 +172,7 @@ export namespace Evaluate {
 
     // INTERFACES
     export function isPackageMetadata(obj: any): obj is PackageMetadata {
-        return obj && isPackageName(obj.Name) && isPackageID(obj.ID) && isPackageVersion(obj.Version);
+        return obj && isPackageName(obj.Name) && (isPackageID(obj.ID) || obj.ID === null) && isPackageVersion(obj.Version);
     }
 
     export function isPackageData(obj: any): obj is PackageData { // technically a union type not an interface
@@ -184,7 +184,7 @@ export namespace Evaluate {
     }
 
     export function isUser(obj: any): obj is User {
-        return obj && obj.name && obj.isAdmin && typeof obj.name === 'string' && typeof obj.isAdmin === 'boolean';
+        return obj && obj.name && typeof obj.name === 'string' && typeof obj.isAdmin === 'boolean';
     }
     
     export function isUserAuthetificationInfo(obj: any): obj is UserAuthenticationInfo {
@@ -193,7 +193,7 @@ export namespace Evaluate {
     
     export function isPackageRating(obj: any): obj is PackageRating {
         return (
-            obj && obj.BusFactor && obj.Correctness && obj.RampUp && obj.ResponsiveMaintainer && obj.LicenseScore && obj.GoodPinningPractice && obj.PullRequest && obj.NetScore &&
+            obj &&
             typeof obj.BusFactor === 'number' && obj.BusFactor >= 0 && obj.BusFactor <= 1 &&
             typeof obj.Correctness === 'number' && obj.Correctness >= 0 && obj.Correctness <= 1 &&
             typeof obj.RampUp === 'number' && obj.RampUp >= 0 && obj.RampUp <= 1 &&
@@ -207,7 +207,7 @@ export namespace Evaluate {
     
     export function isPackageHistoryEntry(obj: any): obj is PackageHistoryEntry {
         return (
-            obj && obj.Date &&
+            obj &&
             typeof obj.Date === 'string' &&
             isAction(obj.Action) &&
             isUser(obj.User) &&

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,5 +1,6 @@
 // for consistency: 
-// import * as Schemas from './schemas';
+// import * as Schemas from '../src/schemas';
+// import Evaluate = Schemas.Evaluate; // if you need to use the type guards
 
 import e from "express";
 import exp from "node:constants";
@@ -135,7 +136,7 @@ export namespace Evaluate {
 
     // TYPES
     export function isPackageName(obj: any): obj is PackageName {
-        return obj && typeof obj === 'string';
+        return obj && typeof obj === 'string' && obj !== '*';
     }
 
     export function isPackageID(obj: any): obj is PackageID {
@@ -174,7 +175,7 @@ export namespace Evaluate {
         return obj && isPackageName(obj.Name) && isPackageID(obj.ID) && isPackageVersion(obj.Version);
     }
 
-    export function isPackageData(obj: any): obj is PackageData {
+    export function isPackageData(obj: any): obj is PackageData { // technically a union type not an interface
         return obj && (isPackageContent(obj) || isPackageURL(obj) || isPackageJSProgram(obj));
     }
 
@@ -186,21 +187,21 @@ export namespace Evaluate {
         return obj && obj.name && obj.isAdmin && typeof obj.name === 'string' && typeof obj.isAdmin === 'boolean';
     }
     
-    export function isUserAuthenticationInfo(obj: any): obj is UserAuthenticationInfo {
+    export function isUserAuthetificationInfo(obj: any): obj is UserAuthenticationInfo {
         return obj && obj.password && typeof obj.password === 'string';
     }
     
     export function isPackageRating(obj: any): obj is PackageRating {
         return (
             obj && obj.BusFactor && obj.Correctness && obj.RampUp && obj.ResponsiveMaintainer && obj.LicenseScore && obj.GoodPinningPractice && obj.PullRequest && obj.NetScore &&
-            typeof obj.BusFactor === 'number' &&
-            typeof obj.Correctness === 'number' &&
-            typeof obj.RampUp === 'number' &&
-            typeof obj.ResponsiveMaintainer === 'number' &&
-            typeof obj.LicenseScore === 'number' &&
-            typeof obj.GoodPinningPractice === 'number' &&
-            typeof obj.PullRequest === 'number' &&
-            typeof obj.NetScore === 'number'
+            typeof obj.BusFactor === 'number' && obj.BusFactor >= 0 && obj.BusFactor <= 1 &&
+            typeof obj.Correctness === 'number' && obj.Correctness >= 0 && obj.Correctness <= 1 &&
+            typeof obj.RampUp === 'number' && obj.RampUp >= 0 && obj.RampUp <= 1 &&
+            typeof obj.ResponsiveMaintainer === 'number' && obj.ResponsiveMaintainer >= 0 && obj.ResponsiveMaintainer <= 1 &&
+            typeof obj.LicenseScore === 'number' && obj.LicenseScore >= 0 && obj.LicenseScore <= 1 &&
+            typeof obj.GoodPinningPractice === 'number' && obj.GoodPinningPractice >= 0 && obj.GoodPinningPractice <= 1 &&
+            typeof obj.PullRequest === 'number' && obj.PullRequest >= 0 && obj.PullRequest <= 1 &&
+            typeof obj.NetScore === 'number' && obj.NetScore >= 0 && obj.NetScore <= 1
         );
     }
     

--- a/tests/schemas.test.ts
+++ b/tests/schemas.test.ts
@@ -1,0 +1,361 @@
+import * as Schemas from '../src/schemas';
+import Evaluate = Schemas.Evaluate;
+import Actions = Schemas.Actions;
+import { describe, test, expect, beforeAll } from '@jest/globals';
+import exp from 'constants';
+
+const badObjs: any[] = [1, 2, 3, '1', '2', '3', {Name:"name", garbage:"garbage"}, 'UPDATE2', 'DOWNLOAD3', 'RATE4'];
+
+describe('ENUMS Evaluation', () => {
+    test('isAction - True', () => {
+        ["CREATE", "DOWNLOAD", "RATE", "UPDATE", Actions.CREATE, Actions.DOWNLOAD, Actions.RATE, Actions.UPDATE].forEach(action => {
+            expect(Evaluate.isAction(action)).toBeTruthy();
+        });
+    });
+
+    test('isAction - False', () => {
+        ["", "create", "update", "download", "rate", 1, 2, 3, '1', '2', '3', 'CREATE1', 'UPDATE2', 'DOWNLOAD3', 'RATE4']
+        .forEach(action => {
+            expect(Evaluate.isAction(action)).toBeFalsy();
+        });
+    });
+});
+
+describe('TYPES Evaluation', () => {
+    // isPackageName
+    test('isPackageName - True', () => {
+        ["test", "test1", "test2", "test3", "test4", "test5", "test6", "test7", "test8"].forEach(packageName => {
+            expect(Evaluate.isPackageName(packageName)).toBeTruthy();
+        });
+    });
+    test('isPackageName - False', () => {
+        expect(Evaluate.isPackageName("")).toBeFalsy();
+        expect(Evaluate.isPackageName("*")).toBeFalsy();
+    });
+
+    // isPackageID
+    test('isPackageID - True', () => {
+        ["test", "test1", "test2", "test3", "test4", "test5", "test6", "test7", "test8"].forEach(packageID => {
+            expect(Evaluate.isPackageID(packageID)).toBeTruthy();
+        });
+    });
+    test('isPackageID - False', () => {
+        expect(Evaluate.isPackageID("")).toBeFalsy();
+    });
+
+    // isPackageVersion
+    test('isPackageVersion - True', () => {
+        ["test", "test1", "test2", "test3", "test4", "test5", "test6", "test7", "test8"].forEach(packageVersion => {
+            expect(Evaluate.isPackageVersion(packageVersion)).toBeTruthy();
+        });
+    });
+    test('isPackageVersion - False', () => {
+        expect(Evaluate.isPackageVersion("")).toBeFalsy();
+    });
+
+    // isPackageContent 
+    // TODO - may be changes if we check for binary differently
+    test('isPackageContent - True', () => {
+        ["test", "test1", "test2", "test3", "test4", "test5", "test6", "test7", "test8"].forEach(packageContent => {
+            expect(Evaluate.isPackageContent(packageContent)).toBeTruthy();
+        });
+    });
+    test('isPackageContent - False', () => {
+        expect(Evaluate.isPackageContent("")).toBeFalsy();
+    });
+
+    // isPackageURL
+    // TODO - may be changes if we check for url differently (very likley will)
+    test('isPackageURL - True', () => {
+        ["test", "test1", "test2", "test3", "test4", "test5", "test6", "test7", "test8"].forEach(packageURL => {
+            expect(Evaluate.isPackageURL(packageURL)).toBeTruthy();
+        });
+    });
+    test('isPackageURL - False', () => {
+        expect(Evaluate.isPackageURL("")).toBeFalsy();
+    });
+
+    // isPackageJSProgram
+    // TODO - may be changes if we check for JS program differently
+    test('isPackageJSProgram - True', () => {
+        ["test", "test1", "test2", "test3", "test4", "test5", "test6", "test7", "test8"].forEach(packageJSProgram => {
+            expect(Evaluate.isPackageJSProgram(packageJSProgram)).toBeTruthy();
+        });
+    });
+    test('isPackageJSProgram - False', () => {
+        expect(Evaluate.isPackageJSProgram("")).toBeFalsy();
+    });
+
+    // isSemverRange
+    // TODO - might change checking for this
+    test('isSemverRange - True', () => {
+        ["test", "test1", "test2", "test3", "test4", "test5", "test6", "test7", "test8"].forEach(semverRange => {
+            expect(Evaluate.isSemverRange(semverRange)).toBeTruthy();
+        });
+    });
+    test('isSemverRange - False', () => {
+        expect(Evaluate.isSemverRange("")).toBeFalsy();
+    });
+
+    // isPackageRegEx
+    // TODO - might change checking for this
+    test('isPackageRegEx - True', () => {
+        ["test", "test1", "test2", "test3", "test4", "test5", "test6", "test7", "test8"].forEach(packageRegEx => {
+            expect(Evaluate.isPackageRegEx(packageRegEx)).toBeTruthy();
+        });
+    });
+    test('isPackageRegEx - False', () => {
+        expect(Evaluate.isPackageRegEx("")).toBeFalsy();
+    });
+});
+
+describe('INTERFACES', () => {
+    // isPackageMetadata
+    test('isPackageMetadata - True', () => {
+        expect(Evaluate.isPackageMetadata({
+            Name: "test",
+            ID: "test",
+            Version: "test"
+        })).toBeTruthy();
+        expect(Evaluate.isPackageMetadata({
+            Name: "test1",
+            ID: null,
+            Version: "test2"
+        })).toBeTruthy();
+    });
+    test('isPackageMetadata - False', () => {
+        expect(Evaluate.isPackageMetadata({
+            Name: "",
+            ID: "",
+            Version: ""
+        })).toBeFalsy();
+        badObjs.forEach(obj => {
+            expect(Evaluate.isPackageMetadata(obj)).toBeFalsy();
+        });
+    });
+
+    // isPackageData (technically is a union type, not interface)
+    test('isPackageData - True', () => {
+        ["test", "test1", "test2", "test3", "test4", "test5", "test6", "test7", "test8"].forEach(data => {
+            expect(Evaluate.isPackageData(data)).toBeTruthy();
+        });
+    });
+    test('isPackageData - False', () => {
+        expect(Evaluate.isPackageData("")).toBeFalsy();
+    });
+
+    // isPackage
+    test('isPackage - True', () => {
+        expect(Evaluate.isPackage({
+            data: "test",
+            metadata: {
+                Name: "test",
+                ID: "test",
+                Version: "test"
+            }
+        })).toBeTruthy();
+        expect(Evaluate.isPackage({
+            data: "test",
+            metadata: {
+                Name: "test",
+                ID: null,
+                Version: "test"
+            }
+        })).toBeTruthy();
+    });
+    test('isPackage - False', () => {
+        expect(Evaluate.isPackage({
+            data: "",
+            metadata: {
+                Name: "",
+                ID: "",
+                Version: ""
+            }
+        })).toBeFalsy();
+        badObjs.forEach(obj => {
+            expect(Evaluate.isPackage(obj)).toBeFalsy();
+        });
+    });
+
+    // isUser
+    test('isUser - True', () => {
+        expect(Evaluate.isUser({
+            name: "test",
+            isAdmin: true
+        })).toBeTruthy();
+        expect(Evaluate.isUser({
+            name: "test",
+            isAdmin: false
+        })).toBeTruthy();
+    });
+    test('isUser - False', () => {
+        expect(Evaluate.isUser({
+            name: "",
+            isAdmin: true
+        })).toBeFalsy();
+        expect(Evaluate.isUser({
+            name: "",
+            isAdmin: false
+        })).toBeFalsy();
+        badObjs.forEach(obj => {
+            expect(Evaluate.isUser(obj)).toBeFalsy();
+        });
+    });
+
+    // isUserAuthetificationInfo
+    test('isUserAuthetificationInfo - True', () => {
+        expect(Evaluate.isUserAuthetificationInfo({
+            password: "test"
+        })).toBeTruthy();
+    });
+    test('isUserAuthetificationInfo - False', () => {
+        expect(Evaluate.isUserAuthetificationInfo({
+            password: ""
+        })).toBeFalsy();
+        badObjs.forEach(obj => {
+            expect(Evaluate.isUserAuthetificationInfo(obj)).toBeFalsy();
+        });
+    });
+
+    // isPackageRating
+    test('isPackageRating - True', () => {
+        const truethyRatings: Schemas.PackageRating[] = [{
+            BusFactor: 1,
+            Correctness: 1,
+            RampUp: 1,
+            ResponsiveMaintainer: 1,
+            LicenseScore: 1,
+            GoodPinningPractice: 1,
+            PullRequest: 1,
+            NetScore: 1,
+        }, 
+        {
+            BusFactor: 0,
+            Correctness: 0,
+            RampUp: 0,
+            ResponsiveMaintainer: 0,
+            LicenseScore: 0,
+            GoodPinningPractice: 0,
+            PullRequest: 0,
+            NetScore: 0,
+        },
+        {
+            BusFactor: 0.5,
+            Correctness: 0.5,
+            RampUp: 0.5,
+            ResponsiveMaintainer: 0.5,
+            LicenseScore: 0.5,
+            GoodPinningPractice: 0.5,
+            PullRequest: 0.5,
+            NetScore: 0.5,
+        }];
+        truethyRatings.forEach(rating => {
+            expect(Evaluate.isPackageRating(rating)).toBeTruthy();
+        });
+    });
+    test('isPackageRating - False', () => {
+        const falsyRatings: any[] = [{
+            BusFactor: -1,
+            Correctness: 1,
+            RampUp: 1,
+            ResponsiveMaintainer: 1,
+            LicenseScore: 1,
+            GoodPinningPractice: 1,
+            PullRequest: 1,
+            NetScore: 1,
+        }, 
+        {
+            BusFactor: 2,
+            Correctness: 0,
+            RampUp: 0,
+            ResponsiveMaintainer: 0,
+            LicenseScore: 0,
+            GoodPinningPractice: 0,
+            PullRequest: 0,
+            NetScore: 0,
+        },
+        {
+            BusFactor: 0.5,
+            Correctness: 0.5,
+            RampUp: 0.5,
+            ResponsiveMaintainer: 0.5,
+            LicenseScore: 0.5,
+            GoodPinningPractice: 0.5,
+            PullRequest: 0.5,
+            NetScore: 1.5,
+        }];
+        falsyRatings.forEach(rating => {
+            expect(Evaluate.isPackageRating(rating)).toBeFalsy();
+        });
+        badObjs.forEach(obj => {
+            expect(Evaluate.isPackageRating(obj)).toBeFalsy();
+        });
+    });
+
+    // isPackageHistoryEntry
+    // TODO - may change date checking
+    test('isPackageHistoryEntry - True', () => {
+        expect(Evaluate.isPackageHistoryEntry({
+            Date: "test",
+            Action: Actions.CREATE,
+            User: {
+                name: "test",
+                isAdmin: true
+            },
+            PackageMetadata: {
+                Name: "test",
+                ID: "test",
+                Version: "test"
+            }
+        })).toBeTruthy();
+        expect(Evaluate.isPackageHistoryEntry({
+            Date: "test",
+            Action: Actions.UPDATE,
+            User: {
+                name: "test",
+                isAdmin: false
+            },
+            PackageMetadata: {
+                Name: "test",
+                ID: null,
+                Version: "test"
+            }
+        })).toBeTruthy();
+    });
+    test('isPackageHistoryEntry - False', () => {
+        expect(Evaluate.isPackageHistoryEntry({
+            Date: "",
+            Action: Actions.CREATE,
+            User: {
+                name: "",
+                isAdmin: true
+            },
+            PackageMetadata: {
+                Name: "",
+                ID: "",
+                Version: ""
+            }
+        })).toBeFalsy();
+        badObjs.forEach(obj => {
+            expect(Evaluate.isPackageHistoryEntry(obj)).toBeFalsy();
+        });
+    });
+
+    // isPackageQuery
+    // TODO - may change version checking
+    test('isPackageQuery - True', () => {
+        expect(Evaluate.isPackageQuery({
+            Version: "test",
+            Name: "test"
+        })).toBeTruthy();
+    });
+    test('isPackageQuery - False', () => {
+        expect(Evaluate.isPackageQuery({
+            Version: "",
+            Name: ""
+        })).toBeFalsy();
+        badObjs.forEach(obj => {
+            expect(Evaluate.isPackageQuery(obj)).toBeFalsy();
+        });
+    });
+});


### PR DESCRIPTION
Created validation functions for each schema to allow for type guarding of these types. Each function has appropriate testing associated for the current implementation of the validation. Certain types we may want to change how we validate but there is room for that still. 

For consistency, if you use the validation functions, they are under the namespace 'Evaluate':
import * as Schemas from '../src/schemas';
import Evaluate = Schemas.Evaluate;