### PR TITLE
Schemas Validation for Type Guarding

### DIFF
--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -2,10 +2,6 @@
 // import * as Schemas from '../src/schemas';
 // import Evaluate = Schemas.Evaluate; // if you need to use the type guards
 
-import e from "express";
-import exp from "node:constants";
-
-
 // from inherited code
 export interface CLIOutput {
     'BUS_FACTOR_SCORE': number;


### PR DESCRIPTION
Created validation functions for each schema to allow for type guarding of these types. Each function has appropriate testing associated for the current implementation of the validation. Certain types we may want to change how we validate but there is room for that still.

For consistency, if you use the validation functions, they are under the namespace 'Evaluate':
import * as Schemas from '../src/schemas';
import Evaluate = Schemas.Evaluate;